### PR TITLE
Fix an error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,6 @@ You can also customize the error:
 ```Julia
 @argcheck k > n
 @argcheck size(A) == size(B) DimensionMismatch
-@argcheck det(A) < 0 DomainError()
+@argcheck det(A) < 0 DomainError
 @argcheck false MyCustomError(my, args...)
 ```


### PR DESCRIPTION
Running
```julia
julia> @argcheck det(a) < 0 DomainError()
ERROR: MethodError: no method matching DomainError()
Closest candidates are:
  DomainError(::Any) at boot.jl:258
  DomainError(::Any, ::Any) at boot.jl:259
Stacktrace:
 [1] top-level scope at /Users/qz/.julia/packages/ArgCheck/xX4DA/src/checks.jl:165
```
will throw a `MethodError`, because `DomainError` cannot have empty field. It should be either
```julia
julia> @argcheck det(a) < 0 DomainError
ERROR: DomainError with det(a) < 0 must hold. Got
det(a) => 0.07470301636255529:
```
or `DomainError` with some `msg`:
```julia
julia> @argcheck det(a) < 0 DomainError("error")
ERROR: DomainError with error:

Stacktrace:
 [1] top-level scope at /Users/qz/.julia/packages/ArgCheck/xX4DA/src/checks.jl:165
```