### PR TITLE
add markers to check blocks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,9 @@
 name = "ArgCheck"
 uuid = "dce04be8-c92d-5529-be00-80e4d2c0e197"
 license = "MIT"
-version = "1.0.1"
+version = "1.1"
 
 [deps]
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 julia = "≥ 1.0.0"

--- a/README.md
+++ b/README.md
@@ -29,3 +29,14 @@ You can also customize the error:
 @argcheck det(A) < 0 DomainError
 @argcheck false MyCustomError(my, args...)
 ```
+
+### Performance
+`@argcheck code` is as fast as `@assert` or a hand written `if. That being said it is possible to erase argchecks, much like one can erase bounds checking using `@inbounds`. This is implemented in [OptionalArgChecks.jl](https://github.com/simeonschaub/OptionalArgChecks.jl):
+
+```julia
+using OptionalArgChecks # this also reexports ArgCheck.jl for convenience
+
+f(x) = @argcheck x > 0
+
+@skipargcheck f(-1)
+```

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You can also customize the error:
 ```
 
 ### Performance
-`@argcheck code` is as fast as `@assert` or a hand written `if. That being said it is possible to erase argchecks, much like one can erase bounds checking using `@inbounds`. This is implemented in [OptionalArgChecks.jl](https://github.com/simeonschaub/OptionalArgChecks.jl):
+`@argcheck code` is as fast as `@assert` or a hand written `if`. That being said it is possible to erase argchecks, much like one can erase bounds checking using `@inbounds`. This is implemented in [OptionalArgChecks.jl](https://github.com/simeonschaub/OptionalArgChecks.jl):
 
 ```julia
 using OptionalArgChecks # this also reexports ArgCheck.jl for convenience

--- a/src/ArgCheck.jl
+++ b/src/ArgCheck.jl
@@ -1,4 +1,3 @@
-__precompile__()
 module ArgCheck
 
 using Base.Meta

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -2,6 +2,18 @@ struct CheckError <: Exception
     msg::String
 end
 
+const MARKER_BEGIN_CHECK = :begin_argcheck
+const MARKER_END_CHECK = :end_argcheck
+
+function mark_check(code)
+    # Mark a code block as check, for usage with OptionalArgChecks.jl
+    Expr(:block,
+      Expr(:meta, MARKER_BEGIN_CHECK),
+      code,
+      Expr(:meta, MARKER_END_CHECK),
+     )
+end
+
 Base.showerror(io::IO, err::CheckError) = print(io, "CheckError: $(err.msg)")
 
 abstract type AbstractCheckFlavor end
@@ -87,7 +99,8 @@ function check(ex, checkflavor, options...)
         FallbackFlavor()
     end
     checker = Checker(ex, checkflavor, codeflavor, options)
-    check(checker, codeflavor)
+    inner = check(checker, codeflavor)
+    mark_check(inner)
 end
 
 function is_simple_call(ex)

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -2,15 +2,17 @@ struct CheckError <: Exception
     msg::String
 end
 
-const MARKER_BEGIN_CHECK = :begin_argcheck
-const MARKER_END_CHECK = :end_argcheck
+const MARKER = :argcheck
+
+const MARKER_BEGIN_CHECK = Expr(:meta, :begin_optional, :argcheck)
+const MARKER_END_CHECK = Expr(:meta, :end_optional, :argcheck)
 
 function mark_check(code)
     # Mark a code block as check, for usage with OptionalArgChecks.jl
     Expr(:block,
-      Expr(:meta, MARKER_BEGIN_CHECK),
-      code,
-      Expr(:meta, MARKER_END_CHECK),
+        MARKER_BEGIN_CHECK,
+        code,
+        MARKER_END_CHECK,
      )
 end
 

--- a/test/checks.jl
+++ b/test/checks.jl
@@ -1,4 +1,8 @@
+module TestChecks
+using Test
+using ArgCheck
 using ArgCheck: pretty_string
+using Random: randstring
 
 macro catch_exception_object(code)
     quote
@@ -25,7 +29,7 @@ end
 
     @test_throws ArgumentError @argcheck 1 ≈ 2 == 2
     @argcheck 1 == 1 ≈ 1 < 2 > 1.2
-    @test_throws DimensionMismatch @argcheck 1 < 2 ==3 DimensionMismatch 
+    @test_throws DimensionMismatch @argcheck 1 < 2 ==3 DimensionMismatch
 end
 
 @testset "@argcheck" begin
@@ -35,11 +39,11 @@ end
     x = 1
     @test_throws ArgumentError (@argcheck x > 1)
     @argcheck x>0 # does not throw
-    
+
     n =2; m=3
     @test_throws DimensionMismatch (@argcheck n==m DimensionMismatch)
     @argcheck n==n DimensionMismatch
-    
+
     denominator = 0
     @test_throws DivideError (@argcheck denominator != 0 DivideError())
     @argcheck 1 !=0 DivideError()
@@ -206,14 +210,33 @@ end
 
 @testset "pretty_string" begin
     @test pretty_string("asd") == "\"asd\""
-    
+
     data = rand(10000:99999, 1000)
     str = pretty_string(data)
     @test length(str) < 1000
     @test occursin(string(last(data)), str)
     @test occursin(string(first(data)),str)
     @test !occursin("\n",str)
-    
+
     data = randn()
     @test parse(Float64,pretty_string(data)) === data
 end
+
+@testset "marker" begin
+    for ex in [
+            :(@argcheck some_expr),
+            :(@check some_expr),
+            :(@check A < b),
+            :(@check A < b MyError),
+        ]
+        ex = macroexpand(TestChecks, ex)
+        @test Meta.isexpr(ex, :block)
+        @test first(ex.args) == Expr(:meta, ArgCheck.MARKER_BEGIN_CHECK)
+        @test last(ex.args) == Expr(:meta, ArgCheck.MARKER_END_CHECK)
+    end
+    @test ArgCheck.MARKER_BEGIN_CHECK != ArgCheck.MARKER_END_CHECK
+    @test ArgCheck.MARKER_BEGIN_CHECK isa Symbol
+    @test ArgCheck.MARKER_END_CHECK isa Symbol
+end
+
+end#module

--- a/test/checks.jl
+++ b/test/checks.jl
@@ -231,12 +231,12 @@ end
         ]
         ex = macroexpand(TestChecks, ex)
         @test Meta.isexpr(ex, :block)
-        @test first(ex.args) == Expr(:meta, ArgCheck.MARKER_BEGIN_CHECK)
-        @test last(ex.args) == Expr(:meta, ArgCheck.MARKER_END_CHECK)
+        @test first(ex.args) == ArgCheck.MARKER_BEGIN_CHECK
+        @test last(ex.args) == ArgCheck.MARKER_END_CHECK
     end
     @test ArgCheck.MARKER_BEGIN_CHECK != ArgCheck.MARKER_END_CHECK
-    @test ArgCheck.MARKER_BEGIN_CHECK isa Symbol
-    @test ArgCheck.MARKER_END_CHECK isa Symbol
+    @test Meta.isexpr(ArgCheck.MARKER_BEGIN_CHECK, :meta)
+    @test Meta.isexpr(ArgCheck.MARKER_END_CHECK, :meta)
 end
 
 end#module

--- a/test/perf.jl
+++ b/test/perf.jl
@@ -1,3 +1,4 @@
+module Perf
 # compare performance with plain assertion
 using BenchmarkTools
 using ArgCheck
@@ -35,3 +36,5 @@ for (f_argcheck, f_assert, arg) in benchmarks
     println(f_assert)
     @btime ($f_assert)($arg)
 end
+
+end#module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,2 @@
-using ArgCheck
-
-using Test
-using Random
-
 include("checks.jl")
 include("perf.jl")


### PR DESCRIPTION
```julia
julia> using ArgCheck

julia> @macroexpand @argcheck some_code
quote
    $(Expr(:meta, :begin_argcheck))
    begin
        #= /home/jan/.julia/dev/ArgCheck/src/checks.jl:174 =#
        #= /home/jan/.julia/dev/ArgCheck/src/checks.jl:175 =#
        if some_code
            #= /home/jan/.julia/dev/ArgCheck/src/checks.jl:176 =#
            ArgCheck.nothing
        else
            #= /home/jan/.julia/dev/ArgCheck/src/checks.jl:178 =#
            ArgCheck.throw(ArgCheck.build_error(ArgCheck.FallbackErrorInfo(:some_code, ArgCheck.ArgCh
eckFlavor(), ())))
        end
    end
    $(Expr(:meta, :end_argcheck))
end
```
https://github.com/simeonschaub/OptionalArgChecks.jl/issues/7
cc @simeonschaub