### PR TITLE
Small improvements to the error messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.jl.*.cov
 *.jl.mem
 /Manifest.toml
+
+.lh
+.vscode

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArgCheck"
 uuid = "dce04be8-c92d-5529-be00-80e4d2c0e197"
 license = "MIT"
-version = "2.1.0"
+version = "2.2.0"
 
 [compat]
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -3,8 +3,12 @@ uuid = "dce04be8-c92d-5529-be00-80e4d2c0e197"
 license = "MIT"
 version = "2.1.0"
 
+[deps]
+MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+
 [compat]
 julia = "1"
+MacroTools = "0.5"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/Project.toml
+++ b/Project.toml
@@ -3,12 +3,8 @@ uuid = "dce04be8-c92d-5529-be00-80e4d2c0e197"
 license = "MIT"
 version = "2.1.0"
 
-[deps]
-MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
-
 [compat]
 julia = "1"
-MacroTools = "0.5"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/src/ArgCheck.jl
+++ b/src/ArgCheck.jl
@@ -1,6 +1,8 @@
 module ArgCheck
 
 using Base.Meta
+using MacroTools: @q
+
 export @argcheck, @check, CheckError
 
 include("checks.jl")

--- a/src/ArgCheck.jl
+++ b/src/ArgCheck.jl
@@ -1,8 +1,6 @@
 module ArgCheck
 
 using Base.Meta
-using MacroTools: @q
-
 export @argcheck, @check, CheckError
 
 include("checks.jl")

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -138,14 +138,16 @@ end
 function analyze_call(expr)
     @assert Meta.isexpr(expr, :call)
     args = []
+    kw_args = []
     for item in expr.args[2:end]
         if Meta.isexpr(item, :parameters)
-            append!(args, analyze_call_arg.(item.args, true))
+            append!(kw_args, analyze_call_arg.(item.args, true))
         else
             push!(args, analyze_call_arg(item, false))
         end
     end
     pushfirst!(args, (kind=:calle, expr=expr.args[1], symbol=gensym("calle")))
+    append!(args, kw_args)
     return (args=args, expr=expr)
 end
 

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -235,12 +235,12 @@ function check(c::Checker, ::ComparisonFlavor)
 end
 
 function expr_error_block(info, condition, preamble...)
-    reti = quote
+    @q begin
         $(preamble...)
         if $condition
             nothing
         else
-            $throw_check_error($info)
+            throw_check_error($info)
         end
     end
 end

--- a/src/checks.jl
+++ b/src/checks.jl
@@ -237,14 +237,14 @@ function check(c::Checker, ::ComparisonFlavor)
 end
 
 function expr_error_block(info, condition, preamble...)
-    @q begin
+    quote
         $(preamble...)
         if $condition
             nothing
         else
             throw_check_error($info)
         end
-    end
+    end |> Base.remove_linenums!
 end
 
 @noinline function throw_check_error(info...)::Union{}

--- a/test/checks.jl
+++ b/test/checks.jl
@@ -190,6 +190,17 @@ end
     @test occursin("10", err.msg)
     @test occursin("20", err.msg)
 
+    # check argument orders
+    err = @catch_exception_object @argcheck let 
+        a = 1.0; b = 1.2; atol = 0.1; nvalue = false; rtol = 0.05;
+        @check isapprox(a, b, atol=atol, nans=nvalue; rtol)
+    end
+    locations = map(["a", "b", "atol", "nvalue", "rtol"]) do name
+        findfirst(name, err.msg)
+    end
+    @test all(x -> x isa UnitRange, locations)
+    @test issorted(getindex.(locations, 1))
+
     x = 1.234
     err = @catch_exception_object @argcheck (!isfinite)(x)
     @test occursin(string(x), err.msg)


### PR DESCRIPTION
The two commits improve the error messages by (1) pointing to the correct source locations in the stack traces and (2) printing keyword arguments after the positional ones, as demonstrated by the following example:
```julia
julia> let a = 1.0, b = 1.2, atol = 0.1, rtol = 0.05 
           @check isapprox(a, b, atol=atol; rtol)
       end
ERROR: CheckError: isapprox(a, b, atol = atol; rtol) must hold. Got
a => 1.0
b => 1.2
atol => 0.1
rtol => 0.05
Stacktrace:
 [1] throw_check_error(info::Any)
   @ ArgCheck ~/.julia/dev/ArgCheck.jl/src/checks.jl:253
 [2] top-level scope
   @ REPL[36]:2
```
Notice that the correct source location is displayed in the second stack frame.