### PR TITLE
Support subtype checks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ArgCheck"
 uuid = "dce04be8-c92d-5529-be00-80e4d2c0e197"
 license = "MIT"
-version = "2.2.0"
+version = "2.3.0"
 
 [compat]
 julia = "1"

--- a/test/checks.jl
+++ b/test/checks.jl
@@ -195,7 +195,7 @@ end
         a = 1.0; b = 1.2; atol = 0.1; nvalue = false; rtol = 0.05;
         @check isapprox(a, b, atol=atol, nans=nvalue; rtol)
     end
-    locations = map(["a", "b", "atol", "nvalue", "rtol"]) do name
+    locations = map(["a =>", "b =>", "atol =>", "nvalue =>", "rtol =>"]) do name
         findfirst(name, err.msg)
     end
     @test all(x -> x isa UnitRange, locations)
@@ -206,6 +206,15 @@ end
     @test occursin(string(x), err.msg)
     err = @catch_exception_object @argcheck !isfinite(x)
     @test_broken occursin(string(x), err.msg)
+
+
+    t1 = Int32
+    t2 = Integer
+    err = @catch_exception_object @argcheck t2 <: t1
+    @test occursin(string(t1), err.msg)
+    @test occursin(string(t2), err.msg)
+    @test occursin("t1 =>", err.msg)
+    @test occursin("t2 =>", err.msg)
 end
 
 @testset "complicated calls" begin

--- a/test/perf.jl
+++ b/test/perf.jl
@@ -3,24 +3,24 @@ module Perf
 using BenchmarkTools
 using ArgCheck
 
-truthy(x) = true
+@noinline truthy(x) = x == x
 
-function fallback_argcheck(x)
+@noinline function fallback_argcheck(x)
     @argcheck x
 end
-function comparison_argcheck(x)
+@noinline function comparison_argcheck(x)
     @argcheck x == x
 end
-function call_argcheck(x)
+@noinline function call_argcheck(x)
     @argcheck truthy(x)
 end
-function fallback_assert(x)
+@noinline function fallback_assert(x)
     @assert x
 end
-function comparison_assert(x)
+@noinline function comparison_assert(x)
     @assert x == x
 end
-function call_assert(x)
+@noinline function call_assert(x)
     @assert truthy(x)
 end
 
@@ -30,11 +30,11 @@ benchmarks =[
     (comparison_assert, comparison_argcheck, 42),
     ]
 
-for (f_argcheck, f_assert, arg) in benchmarks
-    println(f_argcheck)
-    @btime ($f_argcheck)($arg)
+for (f_assert, f_argcheck, arg) in benchmarks
     println(f_assert)
     @btime ($f_assert)($arg)
+    println(f_argcheck)
+    @btime ($f_argcheck)($arg)
 end
 
 end#module

--- a/test/perf.jl
+++ b/test/perf.jl
@@ -4,6 +4,7 @@ using BenchmarkTools
 using ArgCheck
 
 @noinline truthy(x) = x == x
+truthy2(x) = true
 
 @noinline function fallback_argcheck(x)
     @argcheck x
@@ -14,6 +15,9 @@ end
 @noinline function call_argcheck(x)
     @argcheck truthy(x)
 end
+function call_argcheck2(x)
+    @argcheck truthy2(x)
+end
 @noinline function fallback_assert(x)
     @assert x
 end
@@ -23,10 +27,14 @@ end
 @noinline function call_assert(x)
     @assert truthy(x)
 end
+function call_assert2(x)
+    @assert truthy2(x)
+end
 
 benchmarks =[
     (fallback_assert, fallback_argcheck, true),
     (call_assert, call_argcheck, 42),
+    (call_assert2, call_argcheck2, 42),
     (comparison_assert, comparison_argcheck, 42),
     ]
 


### PR DESCRIPTION
This PR fixes #36.

Now the code below
```julia
julia> 
using ArgCheck
A = Int
B = Float64
@argcheck A <: B
```
prints the following
```
ERROR: ArgumentError: A <: B must hold. Got
A => Int64
B => Float64
Stacktrace:
 [1] throw_check_error(info::Any)
   @ ArgCheck ~/.julia/dev/ArgCheck.jl/src/checks.jl:280
 [2] top-level scope
   @ REPL[4]:1
```