### PR TITLE
Fix DomainError in docstring

### DIFF
--- a/src/checks.jl
+++ b/src/checks.jl
@@ -73,7 +73,7 @@ Usage is as follows:
 function myfunction(k,n,A,B)
     @argcheck k > n
     @argcheck size(A) == size(B) DimensionMismatch
-    @argcheck det(A) < 0 DomainError()
+    @argcheck det(A) < 0 DomainError
     # doit
 end
 ```
@@ -92,7 +92,7 @@ Usage is as follows:
 ```Julia
 @check k > n
 @check size(A) == size(B) DimensionMismatch
-@check det(A) < 0 DomainError()
+@check det(A) < 0 DomainError
 ```
 See also [`@argcheck`](@ref).
 """


### PR DESCRIPTION
```julia
julia> @argcheck det(A) < 0 DomainError()
ERROR: MethodError: no method matching DomainError()
The type `DomainError` exists, but no method is defined for this combination of argument types when trying to construct it.

Closest candidates are:
  DomainError(::Any, ::Any)
   @ Core boot.jl:356
  DomainError(::Any)
   @ Core boot.jl:355

Stacktrace:
 [1] top-level scope
   @ REPL[17]:1

julia> @argcheck det(A) < 0 DomainError
ERROR: DomainError with det(A) < 0 must hold. Got
det(A) => 0.0:

Stacktrace:
 [1] throw_check_error(info::Any)
   @ ArgCheck ~/.julia/packages/ArgCheck/DaoPJ/src/checks.jl:283
 [2] top-level scope
   @ REPL[18]:1
```